### PR TITLE
Steps to fix prepush hooks error

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,17 @@ To push without running the pre-push hook (e.g. doc updates):
 git push <remote> --no-verify
 ```
 
+Note: If while pushing you encounter this error "Could not initialize class org.codehaus.groovy.runtime.InvokerHelper" then downgrade your java version to java11
+
+Steps to downgrade Java Version: 
+1. Install Homebrew (https://brew.sh/)
+2. run ```brew update```
+3. To uninstall your current java version, run ```sudo rm -fr /Library/Java/JavaVirtualMachines/<jdk-version>```
+4. run ```brew tap homebrew/cask-versions```
+5. run ```brew search java```
+6. If you see java11, then run ```brew install java11```
+7. Verify java-version by running ```java -version```
+
 ## local.properties helpers
 There are multiple helper flags available via `local.properties` that will help speed up local development workflow
 when working across multiple layers of the dependency stack - specifically, with android-components, geckoview or application-services.

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ To push without running the pre-push hook (e.g. doc updates):
 git push <remote> --no-verify
 ```
 
-Note: If while pushing you encounter this error "Could not initialize class org.codehaus.groovy.runtime.InvokerHelper" then downgrade your java version to java11
+Note: If while pushing you encounter this error "Could not initialize class org.codehaus.groovy.runtime.InvokerHelper" and are currently on Java14 then downgrading your Java version to Java13 or lower can resolve the issue
 
-Steps to downgrade Java Version: 
+Steps to downgrade Java Version on Mac with Brew: 
 1. Install Homebrew (https://brew.sh/)
 2. run ```brew update```
 3. To uninstall your current java version, run ```sudo rm -fr /Library/Java/JavaVirtualMachines/<jdk-version>```


### PR DESCRIPTION
Updating Readme to include fix to error "Could not initialize class org.codehaus.groovy.runtime.InvokerHelper" which came up while running prepush hooks



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture